### PR TITLE
3.0.0 Version with Hibernate and other version bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+- package-ecosystem: maven
+  directory: "/"
+  schedule:
+    interval: daily
+    time: "20:00"
+  open-pull-requests-limit: 200

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
         <logging-starter.version>0.10.2</logging-starter.version>
 
         <!-- Misc -->
-        <hibernate.version>5.4.24.Final</hibernate.version>
+        <hibernate.version>5.2.18.Final</hibernate.version>
         <p6spy.version>3.0.0</p6spy.version>
         <commons-collections.version>3.2.2</commons-collections.version>
         <guava.version>24.1.1-jre</guava.version>

--- a/pom.xml
+++ b/pom.xml
@@ -17,25 +17,25 @@
         <logging-starter.version>0.10.2</logging-starter.version>
 
         <!-- Misc -->
-        <hibernate.version>5.2.18.Final</hibernate.version>
+        <hibernate.version>5.4.24.Final</hibernate.version>
         <p6spy.version>3.0.0</p6spy.version>
         <commons-collections.version>3.2.2</commons-collections.version>
         <guava.version>24.1.1-jre</guava.version>
-        <apache.commons.version>3.6</apache.commons.version>
+        <apache.commons.version>3.11</apache.commons.version>
         <h2.version>1.4.191</h2.version>
-        <lombok.version>1.18.12</lombok.version>
+        <lombok.version>1.18.16</lombok.version>
         <lombok.encoding>UTF-8</lombok.encoding>
 
         <!-- Testing -->
-        <junit.version>5.6.2</junit.version>
+        <junit.version>5.7.0</junit.version>
         <hamcrest.version>2.2</hamcrest.version>
 
         <!-- Plugins -->
-        <maven-compiler.version>3.8.0</maven-compiler.version>
+        <maven-compiler.version>3.8.1</maven-compiler.version>
         <maven-surefire-plugin.version>2.22.2</maven-surefire-plugin.version>
         <maven.compiler.source>8</maven.compiler.source>
         <maven.compiler.target>8</maven.compiler.target>
-        <lombok-maven-plugin.version>1.18.12.0</lombok-maven-plugin.version>
+        <lombok-maven-plugin.version>1.18.16.0</lombok-maven-plugin.version>
     </properties>
 
     <distributionManagement>
@@ -210,6 +210,11 @@
                 </configuration>
             </plugin>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <version>3.1.2</version>
+            </plugin>
+            <plugin>
                 <groupId>org.projectlombok</groupId>
                 <artifactId>lombok-maven-plugin</artifactId>
                 <version>${lombok-maven-plugin.version}</version>
@@ -230,7 +235,7 @@
             <plugin>
                 <groupId>com.amashchenko.maven.plugin</groupId>
                 <artifactId>gitflow-maven-plugin</artifactId>
-                <version>1.8.0</version>
+                <version>1.15.0</version>
                 <configuration>
                     <verbose>true</verbose>
                     <versionDigitToIncrement>2</versionDigitToIncrement>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.vgs</groupId>
     <artifactId>vgs-track</artifactId>
-    <version>2.2.1-SNAPSHOT</version>
+    <version>3.0.0</version>
     <name>Track</name>
     <description>Track</description>
 


### PR DESCRIPTION
## Fixes Updates needed for SR-56
<!-- section -->
## Description of changes in release / Impact of release:

Updates dependent libraries including hibernate.  Also introduces a dependabot configuration so we can continue to keep the project updated.

<!-- section -->
## Value being added to the product or risk being removed by this release
Updates needed so that dependent projects can be updated also

<!-- section --> 
## Who is accountable for this change except yourself?
@yyunikov has been helping

<!-- section -->
## Risks of this release
Hibernate update
<!-- section -->
### Is this a breaking change?
  - [X] Yes
  - [ ] No

<!-- section -->
### If you answered Yes then describe why is it so
Hibernate major version update

<!-- section -->
### Is there a way to disable the change?
  - [X] Deploy the previous release
  - [ ] Use a feature flag
  - [ ] Make a FE change that hides a faulty feature
  - [ ] No

<!-- section -->
#### Additional details go here
Versioned artifacts will continue to exist.  Future fixes can be released as patch versions

<!-- section -->